### PR TITLE
Change orientation to be landscape left or right

### DIFF
--- a/FacesToSmileys.iOS/Info.plist
+++ b/FacesToSmileys.iOS/Info.plist
@@ -27,6 +27,7 @@
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>


### PR DESCRIPTION
Issue #6 : Change orientation to be landscape left or right, this change fix the camera orientation problem on iOS.